### PR TITLE
Add acpiTableExtract.zip to gitignore

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -1,3 +1,3 @@
 .DS_Store
-.git
 Backup
+acpiTableExtract.zip


### PR DESCRIPTION
`acpiTableExtract.zip` is generated by your script and should be excluded from version control. Also, the `.git` directory is ignored by default so we don't need that here
