### PR TITLE
extractACPITables go to current directory

### DIFF
--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -1,0 +1,10 @@
+FRAMEWORKS=-framework IOKit -framework CoreFoundation
+OS_VERSION=-mmacosx-version-min=10.5
+CFLAGS=-O2 -Wall $(FRAMEWORKS) $(OS_VERSION)
+# Set this to have tables dumped in the current directory
+CURRENT_DIRECTORY=-DCURRENT_DIRECTORY
+
+all: extractACPITables
+
+extractACPITables: extractACPITables.c Makefile
+	$(CC) $(CFLAGS) $(CURRENT_DIRECTORY) -o $@ $<

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -1,8 +1,6 @@
 FRAMEWORKS=-framework IOKit -framework CoreFoundation
 OS_VERSION=-mmacosx-version-min=10.5
 CFLAGS=-O2 -Wall $(FRAMEWORKS) $(OS_VERSION)
-# Set this to have tables dumped in the current directory
-CURRENT_DIRECTORY=-DCURRENT_DIRECTORY
 
 all: extractACPITables
 

--- a/Tools/extractACPITables.c
+++ b/Tools/extractACPITables.c
@@ -95,7 +95,6 @@ int main(int argc, char * argv[])
 					if (allTables || (strncasecmp(argv[1], (char *)tableName, strlen(argv[1])) == 0))
 					{
 						sprintf(dirspec, "%s/%s.aml", targetDirectory, tableName);
-
 						if ((filedesc = open(dirspec, O_WRONLY|O_CREAT|O_TRUNC, 0644)) != -1)
 						{
 							write(filedesc, buffer, numBytes);

--- a/Tools/extractACPITables.c
+++ b/Tools/extractACPITables.c
@@ -40,11 +40,22 @@ int main(int argc, char * argv[])
 	int filedesc, status = 0;
 
 	bool allTables = true;
+	bool currentDirectory = false;
 
 	io_service_t	service;
 	CFDictionaryRef	tableDictionary;
 
 	//==================================================================================
+
+	if (argc >= 2)
+	{
+		if (strcmp(argv[1], "-c") == 0)
+		{
+			currentDirectory = true;
+			argc--;
+			argv++;
+		}
+	}
 
 	if (argc == 2)
 	{

--- a/Tools/extractACPITables.c
+++ b/Tools/extractACPITables.c
@@ -73,8 +73,11 @@ int main(int argc, char * argv[])
 
 					if (allTables || (strncasecmp(argv[1], (char *)tableName, strlen(argv[1])) == 0))
 					{
+#ifdef CURRENT_DIRECTORY
+					        sprintf(dirspec, "%s.aml", tableName);
+#else
 						sprintf(dirspec, "%s/Library/ssdtPRGen/%s.aml", homeDirectory, tableName);
-
+#endif
 						if ((filedesc = open(dirspec, O_WRONLY|O_CREAT|O_TRUNC, 0644)) != -1)
 						{
 							write(filedesc, buffer, numBytes);

--- a/Tools/extractACPITables.c
+++ b/Tools/extractACPITables.c
@@ -37,11 +37,22 @@ int main(int argc, char * argv[])
 	int filedesc, status = 0;
 
 	bool allTables = true;
+	bool currentDirectory = false;
 
 	io_service_t	service;
 	CFDictionaryRef	tableDictionary;
 
 	//==================================================================================
+
+	if (argc >= 2)
+	{
+		if (strcmp(argv[1], "-c") == 0)
+		{
+			currentDirectory = true;
+			argc--;
+			argv++;
+		}
+	}
 
 	if (argc == 2)
 	{
@@ -73,11 +84,14 @@ int main(int argc, char * argv[])
 
 					if (allTables || (strncasecmp(argv[1], (char *)tableName, strlen(argv[1])) == 0))
 					{
-#ifdef CURRENT_DIRECTORY
-					        sprintf(dirspec, "%s.aml", tableName);
-#else
-						sprintf(dirspec, "%s/Library/ssdtPRGen/%s.aml", homeDirectory, tableName);
-#endif
+						if (currentDirectory)
+						{
+							sprintf(dirspec, "%s.aml", tableName);
+						}
+						else
+						{
+							sprintf(dirspec, "%s/Library/ssdtPRGen/%s.aml", homeDirectory, tableName);
+						}
 						if ((filedesc = open(dirspec, O_WRONLY|O_CREAT|O_TRUNC, 0644)) != -1)
 						{
 							write(filedesc, buffer, numBytes);

--- a/ssdtPRGen.sh
+++ b/ssdtPRGen.sh
@@ -4,7 +4,7 @@
 #
 # Version 0.9 - Copyright (c) 2012 by RevoGirl
 #
-# Version 17.7 - Copyright (c) 2014 by Pike <PikeRAlpha@yahoo.com>
+# Version 17.8 - Copyright (c) 2014 by Pike <PikeRAlpha@yahoo.com>
 #
 # Readme......: https://github.com/Piker-Alpha/ssdtPRGen.sh/blob/master/README.md
 #
@@ -25,7 +25,7 @@
 #
 # Script version info.
 #
-gScriptVersion=17.7
+gScriptVersion=17.8
 
 #
 # The script expects '0.5' but non-US localizations use '0,5' so we export
@@ -3392,6 +3392,12 @@ function _initBroadwellSetup()
                           ;;
 
     Mac-937CB26E2E02BB01) gTargetMacModel="MacBookAir7,2"
+                          ;;
+
+    Mac-BE0E8AC46FE800CC) gTargetMacModel="MacBook8,1"
+                          ;;
+
+    Mac-F305150B0C7DEEEF) gTargetMacModel="MacBook8,2"
                           ;;
 
     Mac-A369DDC4E67F1C45) gSystemType=1

--- a/ssdtPRGen.sh
+++ b/ssdtPRGen.sh
@@ -2503,7 +2503,7 @@ function _extractAcpiTables()
   # Extracting ACPI tables.
   #
   _debugPrint 'Extracting ACPI tables ... '
-  "${gToolPath}/extractACPITables"
+  (cd "${gPath}" && "${gToolPath}/extractACPITables")
 
   _debugPrint 'Done.\n'
 }

--- a/ssdtPRGen.sh
+++ b/ssdtPRGen.sh
@@ -2511,7 +2511,7 @@ function _extractAcpiTables()
   # Extracting ACPI tables.
   #
   _debugPrint 'Extracting ACPI tables ... '
-  "${gToolPath}/extractACPITables"
+  (cd "${gPath}" && "${gToolPath}/extractACPITables")
 
   _debugPrint 'Done.\n'
 }

--- a/ssdtPRGen.sh
+++ b/ssdtPRGen.sh
@@ -2511,7 +2511,7 @@ function _extractAcpiTables()
   # Extracting ACPI tables.
   #
   _debugPrint 'Extracting ACPI tables ... '
-  (cd "${gPath}" && "${gToolPath}/extractACPITables")
+  "${gToolPath}/extractACPITables"
 
   _debugPrint 'Done.\n'
 }

--- a/ssdtPRGen.sh
+++ b/ssdtPRGen.sh
@@ -2503,7 +2503,7 @@ function _extractAcpiTables()
   # Extracting ACPI tables.
   #
   _debugPrint 'Extracting ACPI tables ... '
-  (cd "${gPath}" && "${gToolPath}/extractACPITables")
+  "${gToolPath}/extractACPITables"
 
   _debugPrint 'Done.\n'
 }

--- a/ssdtPRGen.sh
+++ b/ssdtPRGen.sh
@@ -4,7 +4,7 @@
 #
 # Version 0.9 - Copyright (c) 2012 by RevoGirl
 #
-# Version 17.8 - Copyright (c) 2014 by Pike <PikeRAlpha@yahoo.com>
+# Version 17.9 - Copyright (c) 2014 by Pike <PikeRAlpha@yahoo.com>
 #
 # Readme......: https://github.com/Piker-Alpha/ssdtPRGen.sh/blob/master/README.md
 #
@@ -25,7 +25,7 @@
 #
 # Script version info.
 #
-gScriptVersion=17.8
+gScriptVersion=17.9
 
 #
 # The script expects '0.5' but non-US localizations use '0,5' so we export
@@ -2499,6 +2499,14 @@ function _extractAcpiTables()
       _debugPrint 'Cleanups ...'
       rm "${gPath}/extractACPITables.zip"
   fi
+
+  if [[ $gExtractionPath ]];
+    then
+      #
+      # Export target path for extractACPITables v0.6 and greater.
+      #
+      export SSDTPRGEN_EXTRACTION_PATH="${gExtractionPath}"
+  fi
   #
   # Extracting ACPI tables.
   #
@@ -3682,6 +3690,7 @@ function _getScriptArguments()
           printf "          1 = inject debug statements in: ${gSsdtID}.dsl\n"
           printf "          2 = show debug output\n"
           printf "          3 = both\n"
+          printf "       -${STYLE_BOLD}extract${STYLE_RESET} ACPI tables to [target path]\n"
           printf "       -${STYLE_BOLD}f${STYLE_RESET}requency (clock frequency)\n"
           printf "       -${STYLE_BOLD}h${STYLE_RESET}elp info (this)\n"
           printf "       -${STYLE_BOLD}lfm${STYLE_RESET}ode, lowest idle frequency\n"
@@ -3858,6 +3867,23 @@ function _getScriptArguments()
                           fi
                         else
                           _invalidArgumentError "-d $1"
+                      fi
+                      ;;
+
+                  -extract) shift
+
+                      if [[ "$1" == "." || "$1" == " " ]];
+                        then
+                          #
+                          # Get current path for extractACPITables v0.6 and greater.
+                          #
+                          local currentPath=$(pwd)
+                          gExtractionPath="${currentPath}"
+                        else
+                          #
+                          # Use given path for extractACPITables v0.6 and greater.
+                          #
+                          gExtractionPath="${1}"
                       fi
                       ;;
 


### PR DESCRIPTION
It's easy to turn "extract to pwd" into "extract into arbitrary
directory" but not vice-versa. Change the C source and the script to
take advantage of this.

Makefile included, but not zip file or binaries. Binaries on request.
