### PR TITLE
Allow self-contained operation if no ~/Library/ssdtPRGen

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -1,3 +1,0 @@
-.DS_Store
-Backup
-acpiTableExtract.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+Backup
+acpiTableExtract.zip
+Tools/extractACPITables
+Tools/iasl
+*.aml
+*.dsl


### PR DESCRIPTION
If users already have a `~/Library/ssdtPRGen`, then don't change existing behavior; keep using it.

If the current directory doesn't look like a clone or full download, then don't change previous behavior. Use `~/Library/ssdtPRGen` for all files.

Otherwise, use the current directory tree for our files. Full checkouts should already have downloaded copies of our zip files and data. (If not, download them the regular way into current directory tree.)

---

This patch includes a minor fix for the totally standalone operation of a bare `./ssdtPRGen.sh` (was missing `Tools/` directory.)

This patch parameterizes the name of the GitHub branch to pull data from. As well as `Beta` and `master`, it could be set to `v17.0` to pull files from a precise tag.
