### PR TITLE
Fix show cmd process for Kabylake board-id

### DIFF
--- a/ssdtPRGen.sh
+++ b/ssdtPRGen.sh
@@ -3806,7 +3806,7 @@ function _showSupportedBoardIDsAndModels()
                     ;;
            Skylake) local modelDataList="gSkylakeModelData[@]"
                     ;;
-          Kabylake) local modelDataList="gKabylakeModelData[@]"
+       'Kaby Lake') local modelDataList="gKabyLakeModelData[@]"
                      ;;
   esac
   #


### PR DESCRIPTION
Fix typeo to correctly show Kabylake board-id / model combinations.